### PR TITLE
Eccezione eventlistener

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -1,6 +1,6 @@
 # ITC Events implemented by the Moda Password Manager
 Events sections:
-* [General Use](#general-use)
+* [Default Operations](#default-operations)
 * [Data Operations](#data-operations)
 * [Database Operations](#database-operations)
 * [Google Drive](#google-drive)
@@ -8,7 +8,10 @@ Events sections:
 
 ***
 
-## General Use
+## Default Operations
+The default operations are added by the EventListener itself, thus they cannot be added by using the `addOperation`
+method.
+
 ### Exception Raised
 * Operation: `exception-raised`
 * Sender: Backend

--- a/docs/itc.md
+++ b/docs/itc.md
@@ -23,7 +23,8 @@ Event objects have the following properties:
 Send an event asynchronously.
 
 ### Event receive()
-Set the thread to wait until an event is sent, and returns it.
+Set the thread to wait until an event is sent, and returns it. Only the classes in the same package, or that inherit the
+ITC class, can use it, as other methods required to make a response have protected visibility.
 
 ### Event request(Event request)
 Send an event synchronously, waiting for the response and returns it.

--- a/docs/itc.md
+++ b/docs/itc.md
@@ -13,7 +13,8 @@ handle any operation.
 Event objects have the following properties:
 - _String_ operation: indicates the operation requested
 - _ArrayList\<Object\> data: the data required for the operation
-- _int_ ID: a unique integer used to identify the communication that is automatically set
+- _int_ communicationID: a unique integer that identifies the communication
+- _int_ sequenceNumber: an auto incremental integer that identifies the current state of the communication
 
 \[[List of events supported by the Password Manager](events.md)\]
 

--- a/src/main/java/moda/passwordmanager/backend/Backend.java
+++ b/src/main/java/moda/passwordmanager/backend/Backend.java
@@ -86,8 +86,6 @@ public class Backend extends EventListener {
             }
         });
 
-        addOperation("close-connection", this::closeConnection);
-
         // Save the data and update the service fields
         addOperation("save-data", () -> {
             saveData((Data) getRequestData().getFirst());

--- a/src/main/java/moda/passwordmanager/frontend/FrontendEventListener.java
+++ b/src/main/java/moda/passwordmanager/frontend/FrontendEventListener.java
@@ -11,15 +11,12 @@ import java.util.ArrayList;
 
 public class FrontendEventListener extends EventListener {
 
-    private InterThreadCommunication itc;
-    private boolean runFlag;  // Flag used to indicate when the thread has to stop
-    private Event eventToSend;  // The event that is sent to the Backend
-    private ShowData showData;  // The Listener needs the Show Data Panel to call the service fields
+    private final InterThreadCommunication ITC;
+    private ShowData showData;  // The EventListener needs the Show Data Panel to call the service fields
 
     public FrontendEventListener(InterThreadCommunication itc, ShowData showData){
         super(itc, "Frontend Event Listener");  // Set the name of the thread for debug purposes
-        this.itc = itc;
-        this.runFlag = true;
+        this.ITC = itc;
         this.showData = showData;
 
         initHandler();  // Initialize all the operations to handle
@@ -54,6 +51,7 @@ public class FrontendEventListener extends EventListener {
                     "The following exception occurred in the " +  threadName + "thread", JOptionPane.ERROR_MESSAGE);
 
             closeConnection();  // The "close-connection" event must be sent after the JOptionPane has been closed
+            System.exit(0);  // Terminate the execution of the software
         });
     }
 

--- a/src/main/java/moda/passwordmanager/interthreadcommunication/Event.java
+++ b/src/main/java/moda/passwordmanager/interthreadcommunication/Event.java
@@ -4,32 +4,44 @@ import java.util.ArrayList;
 
 public class Event {
 
-    private final String OPERATION;  // The operation to perform
+    /**
+     * The operation that is request to be performed
+     */
+    private final String OPERATION;
     private ArrayList<Object> data;  // The data that is communicated
 
     /**
-     * The ID, used to identify the Event communication, is unique and randomly generated and can only be accessed
+     * The ID identifies the Event communication, is unique and randomly generated and can only be accessed
      * by package classes
      */
-    private int id;
+    private int communicationID;
+
+    /**
+     * The sequence number identifies the current state of the communication, where 0 is the setup state of the Event
+     * and is increased each time it is sent through the ITC class APIs
+     */
+    private int sequenceNumber;
 
     public Event(String operation){
         this.OPERATION = operation;
         this.data = new ArrayList<>();
-        this.id = -1;
+        this.communicationID = -1;
+        this.sequenceNumber = 0;
     }
 
     public Event(String operation, Object data){
         this.OPERATION = operation;
         this.data = new ArrayList<>();
         this.data.add(data);
-        this.id = -1;
+        this.communicationID = -1;
+        this.sequenceNumber = 0;
     }
 
     public Event(String operation, ArrayList<Object> data){
         this.OPERATION = operation;
         this.data = new ArrayList<>(data);
-        this.id = -1;
+        this.communicationID = -1;
+        this.sequenceNumber = 0;
     }
 
     public void addData(Object data){
@@ -47,20 +59,28 @@ public class Event {
     /**
      * The ID can be set only the first time, and is considered to be a constant after
      */
-    protected void setId(int id){
-        if (this.id == -1){
-            this.id = id;
+    protected void setCommunicationID(int communicationID){
+        if (this.communicationID == -1){
+            this.communicationID = communicationID;
         }
     }
 
-    protected int getId() {
-        return this.id;
+    protected int getCommunicationID() {
+        return this.communicationID;
+    }
+
+    protected void incrementSequenceNumber(){
+        this.sequenceNumber++;
+    }
+
+    protected int getSequenceNumber(){
+        return this.sequenceNumber;
     }
 
     /**
      * Returns whether the ID has been set to a value different than -1
      */
     protected boolean isIdSet(){
-        return this.id != -1;
+        return this.communicationID != -1;
     }
 }

--- a/src/main/java/moda/passwordmanager/interthreadcommunication/EventListener.java
+++ b/src/main/java/moda/passwordmanager/interthreadcommunication/EventListener.java
@@ -10,7 +10,7 @@ import java.util.HashMap;
 public abstract class EventListener extends Thread {
 
     private final InterThreadCommunication ITC;
-    private boolean runFlag;  // Flag used to indicate when the thread has to stop
+    private boolean runFlag;  // Flag used to indicate when the thread has to terminate its execution
 
     /**
      * The request is used by higher level methods to retrieve the data associated with it, or its operation if it's
@@ -22,20 +22,24 @@ public abstract class EventListener extends Thread {
     /**
      * The handlerMap maps the operations with a method reference and it's used by the handleRequest method
      */
-    private HashMap<String, Runnable> handlerMap;
+    private final HashMap<String, Runnable> HANDLER_MAP;
 
     public EventListener(InterThreadCommunication itc){
         super();
         this.ITC = itc;
         this.runFlag = true;
-        this.handlerMap = new HashMap<>();
+        this.HANDLER_MAP = new HashMap<>();
+
+        initDefaultOperations();
     }
 
     public EventListener(InterThreadCommunication itc, String threadName){
         super(threadName);  // Set the name of the thread for log purposes
         this.ITC = itc;
         this.runFlag = true;
-        this.handlerMap = new HashMap<>();
+        this.HANDLER_MAP = new HashMap<>();
+
+        initDefaultOperations();
     }
 
     @Override
@@ -44,6 +48,12 @@ public abstract class EventListener extends Thread {
 
         while (this.runFlag){
             this.request = this.ITC.receive();  // Wait for a request
+
+            // If the sequence number of the event is 2 or higher, it means that the event is response to a request,
+            // thus we can discard it
+            if (this.request.getSequenceNumber() >= 2){
+                continue;
+            }
 
             // Create the response to send to the other queue, where the name of the operation is always the same
             makeResponse(this.request, this.request.getOperation());
@@ -56,17 +66,20 @@ public abstract class EventListener extends Thread {
                 resetResponse();  // Reset the data to send for the next Event
             }
         }
-
     }
 
     /**
-     * Close the connection and terminate the execution
+     * Add the default operations to the handler map
+     */
+    private void initDefaultOperations(){
+        addOperation("close-connection", this::closeConnection);
+    }
+
+    /**
+     * Close the connection and terminate the execution of the thread
      */
     protected void closeConnection(){
         this.runFlag = false;  // Terminate the execution of the thread
-        Event closeConnection = new Event("close-connection");
-        this.ITC.send(closeConnection);
-        System.exit(0);
     }
 
     /**
@@ -81,10 +94,10 @@ public abstract class EventListener extends Thread {
      */
     private void handleRequest(Event request) {
         String operation = request.getOperation();  // Get the operation to perform
-        if (this.handlerMap.containsKey(operation)){
-            this.handlerMap.get(operation).run();  // Execute the method reference
+        if (this.HANDLER_MAP.containsKey(operation)){
+            this.HANDLER_MAP.get(operation).run();  // Execute the method reference
         }else{
-            resetResponse();  // The operation requested is unknown, thus the response is reset
+            throw new UnknownOperationException("The operation " + request.getOperation() + " requested is unknown.");
         }
     }
 
@@ -92,7 +105,10 @@ public abstract class EventListener extends Thread {
      * Add an operation to the handler
      */
     protected void addOperation(String operation, Runnable method) {
-        this.handlerMap.put(operation, method);
+        if (this.HANDLER_MAP.containsKey(operation)){
+            throw new OverriddenOperationException("The operation " + operation + " already exists in the handler map.");
+        }
+        this.HANDLER_MAP.put(operation, method);
     }
 
     /**

--- a/src/main/java/moda/passwordmanager/interthreadcommunication/InterThreadCommunication.java
+++ b/src/main/java/moda/passwordmanager/interthreadcommunication/InterThreadCommunication.java
@@ -10,7 +10,10 @@ public class InterThreadCommunication {
     private final LinkedBlockingQueue<Event> INPUT_QUEUE;  // Receive Event from this queue from the other thread
     private final LinkedBlockingQueue<Event> OUTPUT_QUEUE;  // Send Event from this queue to the other thread
 
-    private ArrayList<Integer> activeIDs;  // This ArrayList is used to ensure that the ID generated must be unique
+    /**
+     * The ArrayList ensures that the ID generated for any communication is unique
+     */
+    private ArrayList<Integer> activeCommunications;
 
     // Collection of semaphores used to set the threads to wait for a specific type of event
     private final static int SEMAPHORE_PERMITS = 0;
@@ -19,9 +22,9 @@ public class InterThreadCommunication {
 
     /**
      * The Events that are synchronous, that means the same thread needs the response from the event it has send,
-     * have their ID number stored here to filter them.
+     * have their communication ID number stored here to filter them.
      */
-    private ArrayList<Integer> synchronousEvents;
+    private ArrayList<Integer> synchronousCommunications;
 
     /**
      * @param inputQueue The Queue that receives the Event objects
@@ -31,8 +34,8 @@ public class InterThreadCommunication {
         this.INPUT_QUEUE = inputQueue;
         this.OUTPUT_QUEUE = outputQueue;
 
-        this.activeIDs = new ArrayList<>();
-        this.synchronousEvents = new ArrayList<>();
+        this.activeCommunications = new ArrayList<>();
+        this.synchronousCommunications = new ArrayList<>();
 
         this.asynchronousSemaphore = new Semaphore(SEMAPHORE_PERMITS);
         this.synchronousSemaphore = new Semaphore(SEMAPHORE_PERMITS);
@@ -86,12 +89,12 @@ public class InterThreadCommunication {
             int eventID = event.getCommunicationID();  // Retrieve the ID of the event
 
             // If the event sent is a response, remove its ID from the active ones
-            if (this.activeIDs.contains(eventID)){
-                this.activeIDs.remove((Integer) eventID);
+            if (this.activeCommunications.contains(eventID)){
+                this.activeCommunications.remove((Integer) eventID);
             }
 
             // Check whether the event is a synchronous one
-            if (this.synchronousEvents.contains(eventID)){
+            if (this.synchronousCommunications.contains(eventID)){
                 this.INPUT_QUEUE.put(event);  // Put the event in the input queue to let it be found by other threads
                 waitAsynchronousEvent();  // Let the thread wait until the synchronous event is removed from the queue
                 return receive();  // Recall the receive method until it founds an asynchronous event to return
@@ -116,8 +119,8 @@ public class InterThreadCommunication {
             // Check whether the ID of the event is the one of the synchronous event we want
             if (event.getCommunicationID() == id){
                 this.synchronousSemaphore.release();
-                this.synchronousEvents.remove((Integer) id);  // Remove the ID from the synchronous events
-                this.activeIDs.remove((Integer) id);  // Remove the ID from the active IDs
+                this.synchronousCommunications.remove((Integer) id);  // Remove the ID from the synchronous events
+                this.activeCommunications.remove((Integer) id);  // Remove the ID from the active IDs
                 return event;
             }else{
                 this.INPUT_QUEUE.put(event);  // Put the event in the response queue to be found by other threads
@@ -153,7 +156,7 @@ public class InterThreadCommunication {
      */
     private void addEventID(Event event){
         int id = generateID();  // Generate a random unique ID
-        this.activeIDs.add(id);  // Add the ID to the active ones
+        this.activeCommunications.add(id);  // Add the ID to the active ones
         event.setCommunicationID(id);  // Set the generated ID
     }
 
@@ -166,7 +169,7 @@ public class InterThreadCommunication {
         int id = random.nextInt(0, Integer.MAX_VALUE);
 
         // Re-generate the ID if it's the same value as one inside the ActiveIDs ArrayList
-        while (this.activeIDs.contains(id)){
+        while (this.activeCommunications.contains(id)){
             id = random.nextInt(0, Integer.MAX_VALUE);
         }
         return id;
@@ -201,7 +204,7 @@ public class InterThreadCommunication {
      * @param ID The ID of the event
      */
     private void addSynchronousEvent(int ID){
-        this.synchronousEvents.add(ID);
+        this.synchronousCommunications.add(ID);
     }
 
 }

--- a/src/main/java/moda/passwordmanager/interthreadcommunication/InterThreadCommunication.java
+++ b/src/main/java/moda/passwordmanager/interthreadcommunication/InterThreadCommunication.java
@@ -54,6 +54,7 @@ public class InterThreadCommunication {
             if (!event.isIdSet()){
                 addEventID(event);
             }
+            event.incrementSequenceNumber();  // Increment the sequence number of the event
             this.OUTPUT_QUEUE.put(event);  // Put the event in the queue to send it to the other thread
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
@@ -67,19 +68,22 @@ public class InterThreadCommunication {
      */
     public Event request(Event request){
         send(request);
-        addSynchronousEvent(request.getId());
-        return receive(request.getId());
+        addSynchronousEvent(request.getCommunicationID());
+        return receive(request.getCommunicationID());
     }
 
     /**
      * Receive an Event from the other Queue
      * @return The event sent
      */
-    public Event receive() {
+    protected Event receive() {
+        // The method has protected as visibility because if a thread, that does not inherit the EventListener class,
+        // receives a synchronous event, it is unable to use the makeResponse method to reply to the request creating a
+        // deadlock for the sender thread
         try {
             Event event = this.INPUT_QUEUE.take();  // Wait for an event sent from the receiver queue
 
-            int eventID = event.getId();  // Retrieve the ID of the event
+            int eventID = event.getCommunicationID();  // Retrieve the ID of the event
 
             // If the event sent is a response, remove its ID from the active ones
             if (this.activeIDs.contains(eventID)){
@@ -88,8 +92,8 @@ public class InterThreadCommunication {
 
             // Check whether the event is a synchronous one
             if (this.synchronousEvents.contains(eventID)){
-                this.INPUT_QUEUE.put(event);  // Put the event in the response queue to be found by other threads
-                waitAsynchronousEvent();  // Let the thread wait until synchronous event is removed from the queue
+                this.INPUT_QUEUE.put(event);  // Put the event in the input queue to let it be found by other threads
+                waitAsynchronousEvent();  // Let the thread wait until the synchronous event is removed from the queue
                 return receive();  // Recall the receive method until it founds an asynchronous event to return
             }else{  // If the event is not a synchronous one, then return it
                 this.asynchronousSemaphore.release();
@@ -110,7 +114,7 @@ public class InterThreadCommunication {
             Event event = this.INPUT_QUEUE.take();  // Wait for an event sent from the receiver queue
 
             // Check whether the ID of the event is the one of the synchronous event we want
-            if (event.getId() == id){
+            if (event.getCommunicationID() == id){
                 this.synchronousSemaphore.release();
                 this.synchronousEvents.remove((Integer) id);  // Remove the ID from the synchronous events
                 this.activeIDs.remove((Integer) id);  // Remove the ID from the active IDs
@@ -127,13 +131,19 @@ public class InterThreadCommunication {
     }
 
     /**
-     * Configurate an Event as a response
+     * Configure an Event as a response
      * @param request The request made by the other queue: its ID is required to use the same communication
      * @param eventOperation The name of the event that will be created
      */
     protected Event makeResponse(Event request, String eventOperation){
-        Event response = new Event(eventOperation);  // Create the event response with the name of the operation
-        response.setId(request.getId());  // Set the ID to be the same as the request one
+        Event response = new Event(eventOperation);  // Create the event response with the operation specified
+
+        // The response needs to have the same sequence number as the request
+        while (response.getSequenceNumber() != request.getSequenceNumber()){
+            response.incrementSequenceNumber();
+        }
+
+        response.setCommunicationID(request.getCommunicationID());  // Set the ID to be the same as the request one
 
         return response;
     }
@@ -144,7 +154,7 @@ public class InterThreadCommunication {
     private void addEventID(Event event){
         int id = generateID();  // Generate a random unique ID
         this.activeIDs.add(id);  // Add the ID to the active ones
-        event.setId(id);  // Set the generated ID
+        event.setCommunicationID(id);  // Set the generated ID
     }
 
     /**

--- a/src/main/java/moda/passwordmanager/interthreadcommunication/OverriddenOperationException.java
+++ b/src/main/java/moda/passwordmanager/interthreadcommunication/OverriddenOperationException.java
@@ -1,0 +1,11 @@
+package moda.passwordmanager.interthreadcommunication;
+
+/**
+ * The OverriddenOperation exception is arisen when an operation that already exists in the handler map is trying to be
+ * readded.
+ */
+public class OverriddenOperationException extends RuntimeException {
+    public OverriddenOperationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/moda/passwordmanager/interthreadcommunication/UnknownOperationException.java
+++ b/src/main/java/moda/passwordmanager/interthreadcommunication/UnknownOperationException.java
@@ -1,0 +1,11 @@
+package moda.passwordmanager.interthreadcommunication;
+
+/**
+ * The UnknownOperation exception is arisen when the EventListener thread receives an event containing an operation
+ * that is not inside the handler map.
+ */
+public class UnknownOperationException extends RuntimeException {
+    public UnknownOperationException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/moda/passwordmanager/interthreadcommunication/EventListenerTests.java
+++ b/src/test/java/moda/passwordmanager/interthreadcommunication/EventListenerTests.java
@@ -6,10 +6,12 @@ import org.junit.jupiter.api.Test;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class EventListenerTests {
 
     private final static String EVENT_NAME = "Test";
+    private final static String EVENT_NAME_2 = "Test_2";
     private InterThreadCommunication sender;
     private EventListener eventListener;
 
@@ -42,5 +44,46 @@ class EventListenerTests {
         assertEquals(EVENT_NAME, response.getOperation());
     }
 
+    /**
+     * Ensure that the EventListener discards any event that has the sequence number equal or greater than 2
+     */
+    @Test
+    void discardEvent(){
+        // Add the operations to the handler map
+        this.eventListener.addOperation(EVENT_NAME, () -> {});
+        this.eventListener.addOperation(EVENT_NAME_2, () -> {});
+
+        // The event which has to be discarded from the EventListener, thus we need to increment the sequence number
+        // two times
+        Event eventToDiscard = new Event(EVENT_NAME);
+        eventToDiscard.incrementSequenceNumber();
+        eventToDiscard.incrementSequenceNumber();
+
+        Event eventToReceive = new Event(EVENT_NAME_2);
+
+        this.sender.send(eventToDiscard);
+        this.sender.send(eventToReceive);
+
+        Event eventListenerResponse = this.sender.receive();
+        assertEquals(EVENT_NAME_2, eventListenerResponse.getOperation());
+    }
+
+    /**
+     * Ensure that readding the same operation to the event listener, raises an OverriddenOperationException
+     */
+    @Test
+    void raiseOverriddenOperationException(){
+        boolean exceptionRaised = false;
+
+        this.eventListener.addOperation(EVENT_NAME, () -> {});
+
+        try{
+            this.eventListener.addOperation(EVENT_NAME, () -> {});
+        }catch (OverriddenOperationException e){
+            exceptionRaised = true;
+        }
+
+        assertTrue(exceptionRaised);
+    }
 
 }

--- a/src/test/java/moda/passwordmanager/interthreadcommunication/EventTests.java
+++ b/src/test/java/moda/passwordmanager/interthreadcommunication/EventTests.java
@@ -24,7 +24,7 @@ class EventTests {
      */
     @Test
     void defaultEventID(){
-        assertEquals(-1, this.event.getId());
+        assertEquals(-1, this.event.getCommunicationID());
     }
 
     /**
@@ -32,8 +32,8 @@ class EventTests {
      */
     @Test
     void setEventID(){
-        this.event.setId(EVENT_ID);
-        assertEquals(EVENT_ID, this.event.getId());
+        this.event.setCommunicationID(EVENT_ID);
+        assertEquals(EVENT_ID, this.event.getCommunicationID());
     }
 
     /**
@@ -41,9 +41,9 @@ class EventTests {
      */
     @Test
     void modifyEventID(){
-        this.event.setId(EVENT_ID);
-        this.event.setId(EVENT_ID+1);
-        assertEquals(EVENT_ID, this.event.getId());
+        this.event.setCommunicationID(EVENT_ID);
+        this.event.setCommunicationID(EVENT_ID+1);
+        assertEquals(EVENT_ID, this.event.getCommunicationID());
     }
 
     /**
@@ -51,7 +51,7 @@ class EventTests {
      */
     @Test
     void isEventIdSet(){
-        this.event.setId(EVENT_ID);
+        this.event.setCommunicationID(EVENT_ID);
         assertTrue(this.event.isIdSet());
     }
 

--- a/src/test/java/moda/passwordmanager/interthreadcommunication/EventTests.java
+++ b/src/test/java/moda/passwordmanager/interthreadcommunication/EventTests.java
@@ -7,8 +7,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class EventTests {
 
-    private final static String EVENT_NAME = "Test";
-    private final static int EVENT_ID = 1;
+    private final static String OPERATION = "Test";
+    private final static int COMMUNICATION_ID = 1;
+    private final static int EVENT_COMMUNICATION_ID_NOT_SET = -1;
+    private final static int EXPECTED_SEQUENCE_NUMBER = 1;
     private Event event;
 
     /**
@@ -16,51 +18,61 @@ class EventTests {
      */
     @BeforeEach
     void init(){
-        this.event = new Event(EVENT_NAME);
+        this.event = new Event(OPERATION);
     }
 
     /**
-     * Ensure that the ID of an event if it's not set, is equal to -1
+     * Ensure that the communication ID of an event if it's not set, is equal to -1
      */
     @Test
-    void defaultEventID(){
+    void defaultCommunicationID(){
         assertEquals(-1, this.event.getCommunicationID());
     }
 
     /**
-     * Ensure that setting the ID of an event works
+     * Ensure that setting the communication ID of an event works
      */
     @Test
-    void setEventID(){
-        this.event.setCommunicationID(EVENT_ID);
-        assertEquals(EVENT_ID, this.event.getCommunicationID());
+    void setCommunicationID(){
+        this.event.setCommunicationID(COMMUNICATION_ID);
+        assertEquals(COMMUNICATION_ID, this.event.getCommunicationID());
     }
 
     /**
-     * Ensure that the value of the ID of an Event cannot be changed
+     * Ensure that the value of the communication ID of an Event cannot be changed
      */
     @Test
-    void modifyEventID(){
-        this.event.setCommunicationID(EVENT_ID);
-        this.event.setCommunicationID(EVENT_ID+1);
-        assertEquals(EVENT_ID, this.event.getCommunicationID());
+    void modifyCommunicationID(){
+        this.event.setCommunicationID(COMMUNICATION_ID);
+        this.event.setCommunicationID(COMMUNICATION_ID+1);
+        assertEquals(COMMUNICATION_ID, this.event.getCommunicationID());
     }
 
     /**
-     * Ensure that when setting an ID the isIdSet method returns true
+     * Ensure that when setting the communication ID, the isIdSet method returns true
      */
     @Test
-    void isEventIdSet(){
-        this.event.setCommunicationID(EVENT_ID);
+    void isCommunicationIDSet(){
+        this.event.setCommunicationID(COMMUNICATION_ID);
         assertTrue(this.event.isIdSet());
     }
 
     /**
-     * Ensure that when the ID is not set yet, the isIdSet method returns false
+     * Ensure that when the communication ID is not set yet, the isIdSet method returns false
      */
     @Test
-    void isEventIdSetFalse(){
+    void isCommunicationIDSetFalse(){
         assertFalse(this.event.isIdSet());
+    }
+
+
+    /**
+     * Ensure that the method 'incrementSequenceNumber' increments the sequence number of the event
+     */
+    @Test
+    void incrementSequenceNumber(){
+        this.event.incrementSequenceNumber();
+        assertEquals(EXPECTED_SEQUENCE_NUMBER, this.event.getSequenceNumber());
     }
 
 }

--- a/src/test/java/moda/passwordmanager/interthreadcommunication/InterThreadCommunicationTests.java
+++ b/src/test/java/moda/passwordmanager/interthreadcommunication/InterThreadCommunicationTests.java
@@ -13,6 +13,9 @@ class InterThreadCommunicationTests {
 
     private final static String EVENT_NAME = "Test";
     private final static int EVENT_ID = 1;
+
+    // The sequence number has to be 1 after the event is sent one time
+    private final static int EVENT_SEQUENCE_SENT_ONE_TIME = 1;
     private InterThreadCommunication sender;
     private InterThreadCommunication receiver;
 
@@ -33,8 +36,13 @@ class InterThreadCommunicationTests {
     @Test
     void sendAndReceiveSameThread(){
         this.sender.send(new Event(EVENT_NAME));
-        Event event = receiver.receive();
+        Event event = this.receiver.receive();
         assertEquals(EVENT_NAME, event.getOperation());
+
+        // Also ensure that the sequence number is 1 as the event has been sent one time
+        // Lastly, it can be asserted only here as the send method is the same for all test cases, thus the same
+        // behaviour is expected
+        assertEquals(EVENT_SEQUENCE_SENT_ONE_TIME, event.getSequenceNumber());
     }
 
     /**

--- a/src/test/java/moda/passwordmanager/interthreadcommunication/InterThreadCommunicationTests.java
+++ b/src/test/java/moda/passwordmanager/interthreadcommunication/InterThreadCommunicationTests.java
@@ -105,11 +105,11 @@ class InterThreadCommunicationTests {
     @Test
     void makeResponse(){
         Event request = new Event(EVENT_NAME);
-        request.setId(EVENT_ID);  // Set the ID of the event
+        request.setCommunicationID(EVENT_ID);  // Set the ID of the event
 
         // Make the response and assert the ID
         Event response = this.sender.makeResponse(request, request.getOperation());
-        assertEquals(EVENT_ID,response.getId());
+        assertEquals(EVENT_ID,response.getCommunicationID());
     }
 
 }


### PR DESCRIPTION
- Aggiornate la documentazioni
- Migliorie generali alla classe FrontendEventListener
- Aggiunto il numero di sequenza agli eventi: permette agli EventListener di identificare la comunicazione in corso
- Aggiunte delle operazioni di default all'EventListener
- Adesso se l'EventListener riceve un'operazione che non è presente nella handler map, invoca un'eccezione di tipo UnknownOperationException
- Adesso se all'EventListener viene aggiunta un'operazione che è stata già aggiunta, invoca un'eccezione di tipo OverriddenOperationException
- Aggiunti i casi di test: "discardEvent" e "raiseOverriddenOperationException" per la classe EventListener
- Aggiunto il caso di test: "incrementSequenceNumber" per la classe Event
- Aggiunto il controllo sul sequence number nel caso di test: "sendAndReceiveSameThread" per la classe InterThreadCommunication