### PR TITLE
Risolto l'errore sulla creazione dei database

### DIFF
--- a/src/main/java/moda/passwordmanager/frontend/panels/settings/Database.java
+++ b/src/main/java/moda/passwordmanager/frontend/panels/settings/Database.java
@@ -100,7 +100,7 @@ public class Database extends Section {
             return;
         }
 
-        Event event = new Event("change-master-password", masterPassword.toCharArray());
+        Event event = new Event("update-master-password", masterPassword.toCharArray());
         getITC().request(event);  // Wait for the end of the operations in the backend
     }
 


### PR DESCRIPTION
- Risolto l'errore dove veniva utilizzato il metodo "change-master-password" invece di "update-master-password" quando è creato un nuovo database