### PR TITLE
0.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>moda</groupId>
     <artifactId>moda-password-manager</artifactId>
-    <version>0.5.1</version>
+    <version>0.5.2</version>
     <name>Moda Password Manager</name>
     <description>Il Moda Password Manager</description>
     <url>https://github.com/Forzooo/Moda-Password-Manager/</url>

--- a/src/main/java/moda/passwordmanager/Application.java
+++ b/src/main/java/moda/passwordmanager/Application.java
@@ -16,7 +16,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 public class Application extends JFrame {
 
     private final static String TITLE = "MODA - Password Manager";
-    private final static String VERSION = "0.5.1";  // The current version of the software
+    private final static String VERSION = "0.5.2";  // The current version of the software
 
     public Application(LinkedBlockingQueue<Event> backendQueue, LinkedBlockingQueue<Event> frontendQueue,
                        String databaseToUse){

--- a/src/main/java/moda/passwordmanager/frontend/panels/settings/Data.java
+++ b/src/main/java/moda/passwordmanager/frontend/panels/settings/Data.java
@@ -9,10 +9,13 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 public class Data extends Section {
 
-    private JButton changeMasterPasswordButton;  // Change the master password of the current database4
+    // Change the master password of the current database
+    private JPasswordField updateMasterPasswordTextField;
+    private JButton updateMasterPasswordButton;
 
     private JTextField stringLengthTextField;
     private JCheckBox stringLettersCheckbox;
@@ -34,11 +37,15 @@ public class Data extends Section {
     }
 
     private void initComponents(){
-        Dimension buttonDimension = new Dimension(250, 20);  // Define the dimension of any JButton
+        JPanel updateMasterPasswordPanel = new JPanel();
 
-        this.changeMasterPasswordButton = new JButton();
-        this.changeMasterPasswordButton.setText("Change the master password");
-        this.changeMasterPasswordButton.setMaximumSize(buttonDimension);
+        this.updateMasterPasswordTextField = new JPasswordField();
+        this.updateMasterPasswordTextField.setPreferredSize(getTextFieldDimension());
+        this.updateMasterPasswordTextField.putClientProperty("JTextField.placeholderText", "New master password");
+
+        this.updateMasterPasswordButton = new JButton();
+        this.updateMasterPasswordButton.setText("Change");
+        this.updateMasterPasswordButton.setMaximumSize(getButtonDimension());
 
         this.stringLengthTextField = new JTextField();
         this.stringLengthTextField.putClientProperty("JTextField.placeholderText", "String length");
@@ -54,9 +61,12 @@ public class Data extends Section {
 
         this.configureStringGenerationButton = new JButton();
         this.configureStringGenerationButton.setText("Change");
-        this.configureStringGenerationButton.setMaximumSize(buttonDimension);
+        this.configureStringGenerationButton.setMaximumSize(getButtonDimension());
 
-        addOption(this.changeMasterPasswordButton);
+        updateMasterPasswordPanel.add(this.updateMasterPasswordTextField);
+        updateMasterPasswordPanel.add(this.updateMasterPasswordButton);
+
+        addOption(updateMasterPasswordPanel);
 
         addSection("String generation:");
         addOption(this.stringLengthTextField, "grow");
@@ -67,37 +77,24 @@ public class Data extends Section {
     }
 
     private void initListeners(){
-        this.changeMasterPasswordButton.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                // Set the master password of the database before using it
-                String masterPassword = JOptionPane.showInputDialog(getRootPane(), "Enter the new master password",
-                        "");
-
-                // Initial checks on the master password entered to ensure that it is a valid string, otherwise abort the
-                // operation
-                if (masterPassword == null || masterPassword.isBlank()){
-                    return;
-                }
-
-                changeMasterPassword(masterPassword);
-            }
-        });
+        this.updateMasterPasswordButton.addActionListener(e -> updateMasterPassword());
 
         this.configureStringGenerationButton.addActionListener(e -> configureStringGeneration());
     }
 
     /**
      * Change the current master password of the database to a new one
-     * @param masterPassword The new master password
      */
-    private void changeMasterPassword(String masterPassword){
+    private void updateMasterPassword(){
+        // Retrieve the master password from the password field
+        String masterPassword = Arrays.toString(this.updateMasterPasswordTextField.getPassword());
+
         // Perform some initial conditions check on the master password
         if (!Utilities.checkMasterPassword(masterPassword.toCharArray())){
             return;
         }
 
-        Event event = new Event("change-master-password", masterPassword.toCharArray());
+        Event event = new Event("update-master-password", masterPassword.toCharArray());
         getITC().request(event);  // Wait for the end of the operations in the backend
     }
 

--- a/src/main/java/moda/passwordmanager/frontend/panels/settings/Database.java
+++ b/src/main/java/moda/passwordmanager/frontend/panels/settings/Database.java
@@ -100,7 +100,7 @@ public class Database extends Section {
             return;
         }
 
-        Event event = new Event("change-master-password", masterPassword.toCharArray());
+        Event event = new Event("update-master-password", masterPassword.toCharArray());
         getITC().request(event);  // Wait for the end of the operations in the backend
     }
 

--- a/src/main/java/moda/passwordmanager/frontend/panels/settings/Database.java
+++ b/src/main/java/moda/passwordmanager/frontend/panels/settings/Database.java
@@ -28,16 +28,13 @@ public class Database extends Section {
     }
 
     private void initComponents(){
-        Dimension textFieldDimension = new Dimension(1600, 30);  // Define the dimension of any JTextField
-        Dimension buttonDimension = new Dimension(250, 20);  // Define the dimension of any JButton
-
         JPanel databaseInUsePanel = new JPanel();
         JLabel databaseInUseLabel = new JLabel();
         databaseInUseLabel.setText("Database in use: ");
 
         this.databasePathTextField = new JTextField();
         this.databasePathTextField.setText(getCurrentDatabasePath());
-        this.databasePathTextField.setMaximumSize(textFieldDimension);
+        this.databasePathTextField.setMaximumSize(getTextFieldDimension());
         this.databasePathTextField.setEditable(false);
 
         databaseInUsePanel.add(databaseInUseLabel);
@@ -47,11 +44,11 @@ public class Database extends Section {
 
         this.newDatabaseButton = new JButton();
         this.newDatabaseButton.setText("New database");
-        this.newDatabaseButton.setMaximumSize(buttonDimension);
+        this.newDatabaseButton.setMaximumSize(getButtonDimension());
 
         this.changeDatabaseButton = new JButton();
         this.changeDatabaseButton.setText("Change database");
-        this.changeDatabaseButton.setMaximumSize(buttonDimension);
+        this.changeDatabaseButton.setMaximumSize(getButtonDimension());
 
         databaseOperations.add(this.newDatabaseButton);
         databaseOperations.add(this.changeDatabaseButton);

--- a/src/main/java/moda/passwordmanager/frontend/panels/settings/GoogleDrive.java
+++ b/src/main/java/moda/passwordmanager/frontend/panels/settings/GoogleDrive.java
@@ -28,13 +28,11 @@ public class GoogleDrive extends Section {
     }
 
     private void initComponents(){
-        Dimension buttonDimension = new Dimension(250, 20);  // Define the dimension of any JButton
-
         this.googleDriveCheckbox = new JCheckBox();
 
         this.synchronizeButton = new JButton();
         this.synchronizeButton.setText("Synchronize");
-        this.synchronizeButton.setMaximumSize(buttonDimension);
+        this.synchronizeButton.setMaximumSize(getButtonDimension());
         this.synchronizeButton.setEnabled(false);  // The sync is allowed only when Google Drive is enabled
 
         this.automaticSynchronizationCheckbox = new JCheckBox();

--- a/src/main/java/moda/passwordmanager/frontend/panels/settings/Section.java
+++ b/src/main/java/moda/passwordmanager/frontend/panels/settings/Section.java
@@ -12,6 +12,9 @@ import java.awt.*;
  */
 public abstract class Section extends JPanel {
 
+    private final static Dimension BUTTON_DIMENSION = new Dimension(250, 20);
+    private final static Dimension TEXT_FIELD_DIMENSION = new Dimension(300, 20);
+
     /**
      * Defines the title of the section. <br>
      * It is displayed inside the Settings dialog.
@@ -95,5 +98,19 @@ public abstract class Section extends JPanel {
      */
     protected InterThreadCommunication getITC(){
         return this.ITC;
+    }
+
+    /**
+     * Get the default dimension of any section's button
+     */
+    public static Dimension getButtonDimension() {
+        return BUTTON_DIMENSION;
+    }
+
+    /**
+     * Get the default dimension of any section's text field
+     */
+    public static Dimension getTextFieldDimension() {
+        return TEXT_FIELD_DIMENSION;
     }
 }


### PR DESCRIPTION
## Modifiche Frontend
- Risolto l'errore dove al cambio del database non si poteva inviare la nuova password
- Resa oscurata la master password del cambio del database
- Spostati nella classe Section le dimensioni di default dei bottoni e dei text field
- Risolto l'errore dove veniva utilizzato l'evento "change-master-password" invece di "update-master-password" quando è creato un nuovo database